### PR TITLE
remove provider name in deploy-meilisearch.sh

### DIFF
--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -66,8 +66,8 @@ else:
 
 # Add your SSH KEY to https://console.cloud.google.com/compute/metadata/sshKeys
 commands = [
-    'curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/{0}/scripts/deploy-meilisearch.sh | sudo bash -s {0} {1}'.format(
-        conf.MEILI_CLOUD_SCRIPTS_VERSION_TAG, 'GCP'),
+    'curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/{0}/scripts/deploy-meilisearch.sh | sudo bash -s {0}'.format(
+        conf.MEILI_CLOUD_SCRIPTS_VERSION_TAG),
 ]
 
 for cmd in commands:


### PR DESCRIPTION
closes #15 

This is meant to simplify the removal of the ssh commands, the cleaning ot the meilisearch-cloud repositories and prepare a potential fix where the ssh keys for the user meilisearch are not copied when a user creates a meilisearch machine through a provider.
