### PR TITLE
Remove ssh commands in build

### DIFF
--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -1,7 +1,4 @@
-from time import sleep
-import os
 import googleapiclient.discovery
-
 import config as conf
 import utils
 
@@ -61,24 +58,6 @@ else:
         zone=conf.GCP_DEFAULT_ZONE,
         instance=conf.INSTANCE_BUILD_NAME
     )
-
-# Execute deploy script via SSH
-
-# Add your SSH KEY to https://console.cloud.google.com/compute/metadata/sshKeys
-commands = [
-    'curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/{0}/scripts/deploy-meilisearch.sh | sudo bash -s {0}'.format(
-        conf.MEILI_CLOUD_SCRIPTS_VERSION_TAG),
-]
-
-for cmd in commands:
-    SSH_COMMAND = 'ssh {user}@{host} -o StrictHostKeyChecking=no "{cmd}"'.format(
-        user=conf.SSH_USER,
-        host=instance_ip,
-        cmd=cmd,
-    )
-    print('EXECUTE COMMAND:', SSH_COMMAND)
-    os.system(SSH_COMMAND)
-    sleep(5)
 
 # Stop instance before image creation
 

--- a/tools/config.py
+++ b/tools/config.py
@@ -9,16 +9,9 @@ MEILI_CLOUD_SCRIPTS_VERSION_TAG = 'v0.19.0'
 
 PUBLISH_IMAGE_NAME = 'meilisearch-v0-19-0-ubuntu-2004-lts-build--15-03-2021-19-10-42'
 
-# Update with the username present in the SSH key added to gcp Compute Engine platform
-#
-# https://console.cloud.google.com/compute/metadata/sshKeys?project=meilisearchimage&authuser=1&folder&organizationId=710828868196
-
-SSH_USER = 'esk'
-
 # Setup environment and settings
 
-PROVIDER_NAME='gcp'
-DEBIAN_BASE_IMAGE_FAMILY='ubuntu-2004-lts'
+DEBIAN_BASE_IMAGE_FAMILY = 'ubuntu-2004-lts'
 IMAGE_DESCRIPTION_NAME = 'MeiliSearch-{} running on {}'.format(
     MEILI_CLOUD_SCRIPTS_VERSION_TAG, DEBIAN_BASE_IMAGE_FAMILY)
 IMAGE_FORMAT = 'vmdk'
@@ -28,9 +21,9 @@ IMAGE_DESTINATION_BUCKET_NAME = 'meilisearch-image'
 SERVICE_ACCOUNT_EMAIL = '591812945139-compute@developer.gserviceaccount.com'
 
 USER_DATA = requests.get(
-    'https://raw.githubusercontent.com/meilisearch/cloud-scripts/{}/scripts/cloud-config.yaml'
+    'https://raw.githubusercontent.com/meilisearch/cloud-scripts/{}/scripts/providers/gcp/cloud-config.yaml'
     .format(MEILI_CLOUD_SCRIPTS_VERSION_TAG)
-).text.replace("unknown_provider", PROVIDER_NAME)
+).text
 
 SNAPSHOT_NAME = 'meilisearch-{}-{}'.format(
     MEILI_CLOUD_SCRIPTS_VERSION_TAG,


### PR DESCRIPTION
closes #18 

This is the first draft for the removal of the ssh commands.

It aims to :
- Simplify the whole process
- Have the same structure in all the meilisearch-cloud repositories
- Easier implementation of the future tests/CI
- Make the maintenance easier

What has been done :
- Remove the ssh commands launched after the instance creation
- Remove SSH_KEY
- Each provider has its own cloud-config.yaml located in cloud-scripts/scripts/providers