### PR TITLE
Create a script to test the image built and add the full process to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,32 @@ on:
       - main
 
 jobs:
+tests:
+    # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
+    # Will still run for each push to bump-meilisearch-v*
+    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
+    name: build-image-test
+    runs-on: ubuntu-latest
+    env:
+      GOOGLE_APPLICATION_CREDENTIALS: 
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: pip3 install -r requirements.txt
+    - name: Set image name as env variable
+      run: echo "IMAGE_NAME=meilisearch_gcp_ci_test_$(date +'%d-%m-%Y-%H-%M-%S')" >> $GITHUB_ENV
+    - name: Build image
+      run: python3 tools/build_image.py $IMAGE_NAME
+    - name: Test image
+      run: python3 tools/test_image.py $IMAGE_NAME
+    - name: Clean image
+      if: ${{ always() }}
+      run: python3 tools/destroy_image.py $IMAGE_NAME
+
   pylint:
     name: pylint
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,6 @@ jobs:
     if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
     name: build-image-test
     runs-on: ubuntu-latest
-    env:
-      GOOGLE_APPLICATION_CREDENTIALS: ${{secrets.GOOGLE_APPLICATION_CREDENTIALS}}
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
@@ -26,6 +24,11 @@ jobs:
         python-version: 3.7
     - name: Install dependencies
       run: pip3 install -r requirements.txt
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@master
+      with:
+        service_account_key: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+        export_default_credentials: true
     - name: Set image name as env variable
       run: echo "IMAGE_NAME=meilisearch-gcp-ci-test-$(date +'%d-%m-%Y-%H-%M-%S')" >> $GITHUB_ENV
     - name: Build image

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 jobs:
-tests:
+  tests:
     # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
     # Will still run for each push to bump-meilisearch-v*
     if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     name: build-image-test
     runs-on: ubuntu-latest
     env:
-      GOOGLE_APPLICATION_CREDENTIALS: 
+      GOOGLE_APPLICATION_CREDENTIALS: ${{secrets.GOOGLE_APPLICATION_CREDENTIALS}}
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: pip3 install -r requirements.txt
     - name: Set image name as env variable
-      run: echo "IMAGE_NAME=meilisearch_gcp_ci_test_$(date +'%d-%m-%Y-%H-%M-%S')" >> $GITHUB_ENV
+      run: echo "IMAGE_NAME=meilisearch-gcp-ci-test-$(date +'%d-%m-%Y-%H-%M-%S')" >> $GITHUB_ENV
     - name: Build image
       run: python3 tools/build_image.py $IMAGE_NAME
     - name: Test image

--- a/tools/config.py
+++ b/tools/config.py
@@ -53,7 +53,6 @@ if ! type cloud-init > /dev/null 2>&1 ; then
   if [ $? == 0 ]; then
     echo "Ran - Success - `date`" >> /root/startup
     systemctl enable cloud-init
-    #systemctl start cloud-init
   else
     echo "Ran - Fail - `date`" >> /root/startup
   fi

--- a/tools/config.py
+++ b/tools/config.py
@@ -11,8 +11,8 @@ PUBLISH_IMAGE_NAME = 'meilisearch-v0-19-0-ubuntu-2004-lts-build--15-03-2021-19-1
 
 # Setup environment and settings
 
-DEBIAN_BASE_IMAGE_PROJECT='debian-cloud'
-DEBIAN_BASE_IMAGE_FAMILY='debian-10'
+DEBIAN_BASE_IMAGE_PROJECT = 'debian-cloud'
+DEBIAN_BASE_IMAGE_FAMILY = 'debian-10'
 IMAGE_DESCRIPTION_NAME = 'MeiliSearch-{} running on {}'.format(
     MEILI_CLOUD_SCRIPTS_VERSION_TAG, DEBIAN_BASE_IMAGE_FAMILY)
 IMAGE_FORMAT = 'vmdk'
@@ -99,6 +99,41 @@ BUILD_INSTANCE_CONFIG = {
                 'key': 'startup-script',
                 'value': STARTUP_SCRIPT
             },
+            {
+                'key': 'block-project-ssh-keys',
+                'value': False
+            }
+        ]
+    }
+}
+
+# DOCS: https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert
+BUILD_INSTANCE_TEST_CONFIG = {
+    'name': INSTANCE_BUILD_NAME,
+    'machineType': INSTANCE_TYPE,
+    'disks': [
+        {
+            'boot': True,
+            'autoDelete': True,
+            'initializeParams': {
+                'sourceImage': '',
+            }
+        }
+    ],
+    'tags': {
+        'items': [
+            'http-server',
+            'https-server'
+        ],
+    },
+    'networkInterfaces': [{
+        'network': 'global/networks/default',
+        'accessConfigs': [
+            {'type': 'ONE_TO_ONE_NAT', 'name': 'External NAT'}
+        ]
+    }],
+    'metadata': {
+        'items': [
             {
                 'key': 'block-project-ssh-keys',
                 'value': False

--- a/tools/destroy_image.py
+++ b/tools/destroy_image.py
@@ -1,0 +1,21 @@
+import sys
+import googleapiclient.discovery
+import config as conf
+
+compute = googleapiclient.discovery.build('compute', 'v1')
+
+if len(sys.argv) > 1:
+    SNAPSHOT_NAME = sys.argv[1]
+else:
+    raise Exception("No snapshot name specified")
+
+print("Destroying image named: {name}...".format(
+    name=SNAPSHOT_NAME))
+
+# Destroy image
+
+print('Deleting image...')
+delete = compute.images().delete(project=conf.GCP_DEFAULT_PROJECT,
+                                 image=SNAPSHOT_NAME).execute()
+print(delete)
+print('Image deleted')

--- a/tools/destroy_image.py
+++ b/tools/destroy_image.py
@@ -17,5 +17,4 @@ print("Destroying image named: {name}...".format(
 print('Deleting image...')
 delete = compute.images().delete(project=conf.GCP_DEFAULT_PROJECT,
                                  image=SNAPSHOT_NAME).execute()
-print(delete)
 print('Image deleted')

--- a/tools/test_image.py
+++ b/tools/test_image.py
@@ -1,0 +1,131 @@
+import sys
+import googleapiclient.discovery
+import config as conf
+import utils
+
+compute = googleapiclient.discovery.build('compute', 'v1')
+
+if len(sys.argv) > 1:
+    SNAPSHOT_NAME = sys.argv[1]
+else:
+    raise Exception("No snapshot name specified")
+
+print("Running test for image named: {name}...".format(
+    name=SNAPSHOT_NAME))
+
+# Get the image for the test
+
+source_image = compute.images().get(project=conf.GCP_DEFAULT_PROJECT,
+                                    image=SNAPSHOT_NAME).execute()
+
+if source_image is None:
+    raise Exception("Couldn't find the specified image: {}".format(
+        SNAPSHOT_NAME))
+
+# Create GCP Compute instance to test MeiliSearch image
+
+print('Creating GCP Compute instance')
+
+instance_config = conf.BUILD_INSTANCE_CONFIG
+instance_config['disks'][0]['initializeParams']['sourceImage'] = source_image['selfLink']
+
+create = compute.instances().insert(
+    project=conf.GCP_DEFAULT_PROJECT,
+    zone=conf.GCP_DEFAULT_ZONE,
+    body=instance_config).execute()
+print('   Instance created. Name: {}'.format(conf.INSTANCE_BUILD_NAME))
+
+
+# Wait for GCP instance to be 'RUNNING'
+
+print('Waiting for GCP Compute instance state to be "RUNNING"')
+state_code, state = utils.wait_for_instance_running(
+    conf.GCP_DEFAULT_PROJECT, conf.GCP_DEFAULT_ZONE, timeout_seconds=600)
+print('   Instance state: {}'.format(state))
+
+if state_code == utils.STATUS_OK:
+    instance = compute.instances().get(project=conf.GCP_DEFAULT_PROJECT,
+                                       zone=conf.GCP_DEFAULT_ZONE, instance=conf.INSTANCE_BUILD_NAME).execute()
+    instance_ip = instance['networkInterfaces'][0]['accessConfigs'][0]['natIP']
+    print('   Instance IP: {}'.format(instance_ip))
+else:
+    print('   Error: {}. State: {}.'.format(state_code, state))
+    utils.terminate_instance_and_exit(
+        compute=compute,
+        project=conf.GCP_DEFAULT_PROJECT,
+        zone=conf.GCP_DEFAULT_ZONE,
+        instance=conf.INSTANCE_BUILD_NAME
+    )
+
+# Wait for Health check after configuration is finished
+
+print('Waiting for MeiliSearch health check (may take a few minutes: config and reboot)')
+HEALTH = utils.wait_for_health_check(instance_ip, timeout_seconds=600)
+if HEALTH == utils.STATUS_OK:
+    print('   Instance is healthy')
+else:
+    print('   Timeout waiting for health check')
+    utils.terminate_instance_and_exit(
+        compute=compute,
+        project=conf.GCP_DEFAULT_PROJECT,
+        zone=conf.GCP_DEFAULT_ZONE,
+        instance=conf.INSTANCE_BUILD_NAME
+    )
+
+# Check version
+
+print('Waiting for Version check')
+try:
+    utils.check_meilisearch_version(
+        instance_ip, conf.MEILI_CLOUD_SCRIPTS_VERSION_TAG)
+except Exception as err:
+    print("   Exception: {}".format(err))
+    utils.terminate_instance_and_exit(
+        compute=compute,
+        project=conf.GCP_DEFAULT_PROJECT,
+        zone=conf.GCP_DEFAULT_ZONE,
+        instance=conf.INSTANCE_BUILD_NAME
+    )
+print('   Version of meilisearch match!')
+
+# Stop instance
+
+print('Stopping GCP instance...')
+instance = compute.instances().get(
+    project=conf.GCP_DEFAULT_PROJECT,
+    zone=conf.GCP_DEFAULT_ZONE,
+    instance=conf.INSTANCE_BUILD_NAME
+).execute()
+
+stop_instance_operation = compute.instances().stop(
+    project=conf.GCP_DEFAULT_PROJECT,
+    zone=conf.GCP_DEFAULT_ZONE,
+    instance=conf.INSTANCE_BUILD_NAME
+).execute()
+
+STOPPED = utils.wait_for_zone_operation(
+    compute=compute,
+    project=conf.GCP_DEFAULT_PROJECT,
+    zone=conf.GCP_DEFAULT_ZONE,
+    operation=stop_instance_operation['name']
+)
+if STOPPED == utils.STATUS_OK:
+    print('   Instance stopped')
+else:
+    print('   Timeout waiting for instace stop operation')
+    utils.terminate_instance_and_exit(
+        compute=compute,
+        project=conf.GCP_DEFAULT_PROJECT,
+        zone=conf.GCP_DEFAULT_ZONE,
+        instance=conf.INSTANCE_BUILD_NAME
+    )
+
+# Delete instance
+
+print('Delete instance...')
+compute.instances().delete(
+    project=conf.GCP_DEFAULT_PROJECT,
+    zone=conf.GCP_DEFAULT_ZONE,
+    instance=conf.INSTANCE_BUILD_NAME
+).execute()
+print('Instance deleted')

--- a/tools/test_image.py
+++ b/tools/test_image.py
@@ -18,15 +18,11 @@ print("Running test for image named: {name}...".format(
 source_image = compute.images().get(project=conf.GCP_DEFAULT_PROJECT,
                                     image=SNAPSHOT_NAME).execute()
 
-if source_image is None:
-    raise Exception("Couldn't find the specified image: {}".format(
-        SNAPSHOT_NAME))
-
 # Create GCP Compute instance to test MeiliSearch image
 
 print('Creating GCP Compute instance')
 
-instance_config = conf.BUILD_INSTANCE_CONFIG
+instance_config = conf.BUILD_INSTANCE_TEST_CONFIG
 instance_config['disks'][0]['initializeParams']['sourceImage'] = source_image['selfLink']
 
 create = compute.instances().insert(

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -42,6 +42,15 @@ def wait_for_health_check(instance_ip, timeout_seconds=None):
     return STATUS_TIMEOUT
 
 
+def check_meilisearch_version(instance_ip, version):
+    resp = requests.get(
+        "http://{}/version".format(instance_ip)).json()
+    if resp["pkgVersion"] in version:
+        return
+    raise Exception(
+        "    The version of meilisearch ({}) does not match the instance ({})".format(version, resp["pkgVersion"]))
+
+
 def wait_for_zone_operation(compute, project, zone, operation, timeout_seconds=None):
     start_time = datetime.datetime.now()
     while timeout_seconds is None \


### PR DESCRIPTION
closes #20 

- Add test_image.py to be use with the snapshot name as arg
- Add destroy_image.py to be use with the snapshot name as arg
- We can now optionnaly use build_image.py with an argument corresponding to the snapshot name
- Add version check in build_image.py and test_image.py
- Add github action to run the test : build an image, test it and create a snapshot from it, test this snapshot by creating an image with it, destroy everything

⚠️  This is a draft as I don't have the GOOGLE_APPLICATION_CREDENTIALS to test it 😺 