### PR TITLE
Add retries until an instance is stopped properly or timeouts

### DIFF
--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -1,3 +1,5 @@
+import datetime
+import time
 import sys
 import googleapiclient.discovery
 import config as conf
@@ -37,7 +39,7 @@ print(f'   Instance created. Name: {conf.INSTANCE_BUILD_NAME}')
 # Wait for GCP instance to be 'RUNNING'
 
 print('Waiting for GCP Compute instance state to be "RUNNING"')
-state_code, state = utils.wait_for_instance_running(
+state_code, state, instance = utils.wait_for_instance_running(
     conf.GCP_DEFAULT_PROJECT, conf.GCP_DEFAULT_ZONE, timeout_seconds=600)
 print(f'   Instance state: {state}')
 
@@ -88,18 +90,36 @@ print('   Version of Meilisearch match!')
 
 # Stop instance before image creation
 
-print('Stopping GCP instance...')
-instance = compute.instances().get(
-    project=conf.GCP_DEFAULT_PROJECT,
-    zone=conf.GCP_DEFAULT_ZONE,
-    instance=conf.INSTANCE_BUILD_NAME
-).execute()
+print(conf.INSTANCE_BUILD_NAME)
 
-stop_instance_operation = compute.instances().stop(
-    project=conf.GCP_DEFAULT_PROJECT,
-    zone=conf.GCP_DEFAULT_ZONE,
-    instance=conf.INSTANCE_BUILD_NAME
-).execute()
+print('Stopping GCP instance...')
+
+TIMEOUT_SECONDS=60
+start_time = datetime.datetime.now()
+IS_TIMEOUT=0
+while IS_TIMEOUT is utils.STATUS_OK:
+    try:
+        print('Trying to stop instance ...')
+        stop_instance_operation = compute.instances().stop(
+            project=conf.GCP_DEFAULT_PROJECT,
+            zone=conf.GCP_DEFAULT_ZONE,
+            instance=conf.INSTANCE_BUILD_NAME
+        ).execute()
+        break
+    except Exception as err:
+        print(f'   Exception: {err}')
+    time.sleep(1)
+    IS_TIMEOUT=utils.check_timeout(start_time, TIMEOUT_SECONDS)
+if IS_TIMEOUT is not utils.STATUS_OK:
+    print('Timeout when trying to stop the instance')
+    utils.terminate_instance_and_exit(
+        compute=compute,
+        project=conf.GCP_DEFAULT_PROJECT,
+        zone=conf.GCP_DEFAULT_ZONE,
+        instance=conf.INSTANCE_BUILD_NAME
+    )
+
+print('Successfully stopped instance')
 
 STOPPED = utils.wait_for_zone_operation(
     compute=compute,

--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -109,7 +109,7 @@ while IS_TIMEOUT is utils.STATUS_OK:
     time.sleep(1)
     IS_TIMEOUT=utils.check_timeout(start_time, TIMEOUT_SECONDS)
 if IS_TIMEOUT is not utils.STATUS_OK:
-    print('Timeout when trying to stop the instance')
+    print('Timeout or an error occurred when trying to stop the instance')
     utils.terminate_instance_and_exit(
         compute=compute,
         project=conf.GCP_DEFAULT_PROJECT,

--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -117,7 +117,7 @@ if IS_TIMEOUT is not utils.STATUS_OK:
         instance=conf.INSTANCE_BUILD_NAME
     )
 
-print('Successfully stopped instance')
+print('Successfully stopped the instance')
 
 STOPPED = utils.wait_for_zone_operation(
     compute=compute,

--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -90,8 +90,6 @@ print('   Version of Meilisearch match!')
 
 # Stop instance before image creation
 
-print(conf.INSTANCE_BUILD_NAME)
-
 print('Stopping GCP instance...')
 
 TIMEOUT_SECONDS=60

--- a/tools/test_image.py
+++ b/tools/test_image.py
@@ -103,7 +103,7 @@ while IS_TIMEOUT is utils.STATUS_OK:
     time.sleep(1)
     IS_TIMEOUT=utils.check_timeout(start_time, TIMEOUT_SECONDS)
 if IS_TIMEOUT is not utils.STATUS_OK:
-    print('Timeout when trying to stop the instance')
+    print('Timeout or an error occurred when trying to stop the instance')
     utils.terminate_instance_and_exit(
         compute=compute,
         project=conf.GCP_DEFAULT_PROJECT,

--- a/tools/test_image.py
+++ b/tools/test_image.py
@@ -111,7 +111,7 @@ if IS_TIMEOUT is not utils.STATUS_OK:
         instance=conf.INSTANCE_BUILD_NAME
     )
 
-print('Successfully stopped instance')
+print('Successfully stopped the instance')
 
 STOPPED = utils.wait_for_zone_operation(
     compute=compute,

--- a/tools/test_image.py
+++ b/tools/test_image.py
@@ -91,7 +91,7 @@ start_time = datetime.datetime.now()
 IS_TIMEOUT=0
 while IS_TIMEOUT is utils.STATUS_OK:
     try:
-        print('Trying to stop instance ...')
+        print('Trying to stop the instance ...')
         stop_instance_operation = compute.instances().stop(
             project=conf.GCP_DEFAULT_PROJECT,
             zone=conf.GCP_DEFAULT_ZONE,

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -22,10 +22,10 @@ def wait_for_instance_running(project, zone, timeout_seconds=None):
                                            instance=conf.INSTANCE_BUILD_NAME).execute()
         if instance['status'] not in ['STAGING', 'PROVISIONING']:
             if instance['status'] == 'RUNNING':
-                return STATUS_OK, instance['status']
-            return STATUS_ERROR, instance['status']
+                return STATUS_OK, instance['status'], instance
+            return STATUS_ERROR, instance['status'], instance
         time.sleep(1)
-    return STATUS_TIMEOUT, None
+    return STATUS_TIMEOUT, None, instance
 
 
 def wait_for_health_check(instance_ip, timeout_seconds=None):


### PR DESCRIPTION
*Problem:*
The CI failed during instance stopping. This error was thrown:
```bash
Traceback (most recent call last):
  File "tools/build_image.py", line 95, in <module>
    instance=conf.INSTANCE_BUILD_NAME
```
```
BrokenPipeError: [Errno 32] Broken pipe
```

*Fix:*
The error was due to the fact that we didn't wait enough for the instance, to be entirely stopped. A cropped response was retrieved leading to a broken pipe error.
To fix this, we added a while loop that retries to stop the instance until completed or timeout.

