### PR TITLE
Update README.md with self hosted bors link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 <p align="center">
   <a href="https://github.com/meilisearch/meilisearch-gcp/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-informational" alt="License"></a>
-  <a href="https://app.bors.tech/repositories/34950"><img src="https://bors.tech/images/badge_small.svg" alt="Bors enabled"></a>
+  <a href="https://ms-bors.herokuapp.com/repositories/69"><img src="https://bors.tech/images/badge_small.svg" alt="Bors enabled"></a>
 </p>
 
 <p align="center">⚡ Meilisearch tools for GCP integration</p>


### PR DESCRIPTION
Using our self hosted bors since the GitHub one is deprecated